### PR TITLE
Feature/add router work/27

### DIFF
--- a/public/images/home.svg
+++ b/public/images/home.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="22" viewBox="0 0 26 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5 22V14.5H15.5V22H21.75V12H25.5L13 0.75L0.5 12H4.25V22H10.5Z" fill="#545454"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,58 @@
 import MainPage from "./pages/MainPage";
 import SignInPage from "./pages/Auth/SignInPage/index";
 import React from "react";
-import { Route, Routes } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import PlaygroudPage from "./pages/Playground";
 import SignUpPage from "./pages/Auth/SignUpPage/index";
 import Game from "./pages/Game";
 import Ranking from "./pages/Ranking";
 import IncorrectNotePage from "pages/IncorrectNote/IncorrectNoteList";
+import PrivatePage from "pages/Auth/components/DivisionAuth/PrivatePage";
+import Root from "pages/Root";
+import ErrorPage from "./pages/ErrorPage";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Root />,
+    errorElement: <ErrorPage />,
+    children: [
+      { path: "/", element: <MainPage /> },
+      { path: "/main", element: <MainPage /> },
+      {
+        path: "/signup",
+        element: (
+          <PrivatePage
+            Component1={MainPage}
+            Component2={SignUpPage}
+            text="이미 로그인된 상태입니다."
+            link="/main"
+            restricted
+          />
+        ),
+      },
+      {
+        path: "/signin",
+        element: (
+          <PrivatePage
+            Component1={MainPage}
+            Component2={SignInPage}
+            text="이미 로그인된 상태입니다."
+            link="/main"
+            restricted
+          />
+        ),
+      },
+      { path: "/incorrectnote", element: <IncorrectNotePage /> },
+      { path: "/game", element: <Game /> },
+      { path: "/rank", element: <Ranking /> },
+      { path: "/playground", element: <PlaygroudPage /> },
+    ],
+  },
+]);
 
 function App() {
-  return (
-    <Routes>
-      <Route path={"/"} element={<MainPage />} />
-      <Route path={"/main"} element={<MainPage />} />
-      <Route path={"/signup"} element={<SignUpPage />} />
-      <Route path={"/signin"} element={<SignInPage />} />
-      <Route path={"/incorrectnote"} element={<IncorrectNotePage />} />
-      <Route path={"/playground"} element={<PlaygroudPage />} />
-      <Route path={"/game"} element={<Game />} />
-      <Route path={"/rank"} element={<Ranking />} />
-    </Routes>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import IncorrectNotePage from "pages/IncorrectNote/IncorrectNoteList";
 import PrivatePage from "pages/Auth/components/DivisionAuth/PrivatePage";
 import Root from "pages/Root";
 import ErrorPage from "./pages/ErrorPage";
+import PublicPage from "pages/Auth/components/DivisionAuth/PublicPage";
 
 const router = createBrowserRouter([
   {
@@ -22,9 +23,8 @@ const router = createBrowserRouter([
       {
         path: "/signup",
         element: (
-          <PrivatePage
-            Component1={MainPage}
-            Component2={SignUpPage}
+          <PublicPage
+            Component={SignUpPage}
             text="이미 로그인된 상태입니다."
             link="/main"
             restricted
@@ -34,17 +34,36 @@ const router = createBrowserRouter([
       {
         path: "/signin",
         element: (
-          <PrivatePage
-            Component1={MainPage}
-            Component2={SignInPage}
+          <PublicPage
+            Component={SignInPage}
             text="이미 로그인된 상태입니다."
             link="/main"
             restricted
           />
         ),
       },
-      { path: "/incorrectnote", element: <IncorrectNotePage /> },
-      { path: "/game", element: <Game /> },
+      {
+        path: "/incorrectnote",
+        element: (
+          <PrivatePage
+            Component={IncorrectNotePage}
+            text="로그인을 해주세요!"
+            link="/signin"
+            restricted
+          />
+        ),
+      },
+      {
+        path: "/game",
+        element: (
+          <PrivatePage
+            Component={Game}
+            text="로그인을 해주세요!"
+            link="/signin"
+            restricted
+          />
+        ),
+      },
       { path: "/rank", element: <Ranking /> },
       { path: "/playground", element: <PlaygroudPage /> },
     ],

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -169,9 +169,16 @@ export const loginUserData = () => {
       },
       onSuccess: (data, variables, context) => {
         console.log("success", data, variables, context);
-        moveHome("/");
-        localStorage.clear();
-        localStorage.setItem("accessToken", data.access);
+        console.log(data.CODE);
+        if (data.CODE === "004") {
+          alert("이메일이 일치하지 않습니다. 다시 입력해주세요!");
+        } else if (data.CODE === "003") {
+          alert("비밀번호가 일치하지 않습니다. 다시 입력해주세요!");
+        } else {
+          moveHome("/");
+          localStorage.clear();
+          localStorage.setItem("accessToken", data.access);
+        }
       },
       onSettled: (data, error, variables, context) => {
         console.log("end");

--- a/src/api/authAxios.ts
+++ b/src/api/authAxios.ts
@@ -176,7 +176,6 @@ export const loginUserData = () => {
           alert("비밀번호가 일치하지 않습니다. 다시 입력해주세요!");
         } else {
           moveHome("/");
-          localStorage.clear();
           localStorage.setItem("accessToken", data.access);
         }
       },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import "index.css";
 import store from "./redux/configStore";
@@ -14,13 +13,13 @@ const root = ReactDOM.createRoot(
 );
 
 root.render(
+  // StrictMode는 개발모드에서만 활성화되고, 프로덕션 빌드에서는 활성화 안됨
+  // 제거하면 alert창 한번 띄워짐
   <React.StrictMode>
-    <BrowserRouter>
-      <Provider store={store}>
-        <QueryClientProvider client={queryClient}>
-          <App />
-        </QueryClientProvider>
-      </Provider>
-    </BrowserRouter>
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </Provider>
   </React.StrictMode>
 );

--- a/src/pages/Auth/SignUpPage/index.tsx
+++ b/src/pages/Auth/SignUpPage/index.tsx
@@ -72,11 +72,11 @@ function SignUpPage() {
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (data) {
-      if (data.status === 400) {
+      if (data.CODE === "001") {
         console.log("중복");
         setEmailValid(false);
-        setEmailErrorMsg("이미 등록된 이메일입니다. 다시 입력해주세요.");
-      } else if (data.status === 200) {
+        setEmailErrorMsg(data.message);
+      } else {
         setEmailValid(true);
         console.log("중복아님");
         setEmailErrorMsg("");
@@ -86,15 +86,6 @@ function SignUpPage() {
 
   const sendDuplicateEmail = () => {
     checkDupliEmail(email);
-    // if (data.status === 400) {
-    //   console.log("중복");
-    //   setEmailValid(false);
-    //   setEmailErrorMsg("이미 등록된 이메일입니다. 다시 입력해주세요.");
-    // } else if (data.status === 200) {
-    //   setEmailValid(true);
-    //   console.log("중복아님");
-    //   setEmailErrorMsg("");
-    // }
   };
 
   // 닉네임 입력값
@@ -122,10 +113,11 @@ function SignUpPage() {
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (dataNickname) {
-      if (dataNickname.status === 400) {
+      if (dataNickname.CODE === "002") {
         setNickNameValid(false);
-        setNicknameErrorMsg("이미 등록된 닉네임입니다. 다시 입력해주세요.");
-      } else if (dataNickname.status === 200) {
+        setNicknameErrorMsg(dataNickname.message);
+      } else {
+        console.log(dataNickname.status);
         setNickNameValid(true);
         setNicknameErrorMsg("");
       }

--- a/src/pages/Auth/components/DivisionAuth/IsLogin.tsx
+++ b/src/pages/Auth/components/DivisionAuth/IsLogin.tsx
@@ -1,0 +1,3 @@
+export default function IsLogin() {
+  return !(localStorage.getItem("accessToken") == null);
+}

--- a/src/pages/Auth/components/DivisionAuth/PrivatePage.tsx
+++ b/src/pages/Auth/components/DivisionAuth/PrivatePage.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import IsLogin from "./IsLogin";
+
+export default function PrivatePage({
+  Component1,
+  Component2,
+  text,
+  link,
+}: any) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (IsLogin()) {
+      navigate(link, { replace: true });
+      alert(text);
+    }
+  }, [IsLogin]);
+
+  return IsLogin() ? <Component1 /> : <Component2 />;
+}

--- a/src/pages/Auth/components/DivisionAuth/PrivatePage.tsx
+++ b/src/pages/Auth/components/DivisionAuth/PrivatePage.tsx
@@ -1,20 +1,16 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import IsLogin from "./IsLogin";
+import MainPage from "pages/MainPage";
 
-export default function PrivatePage({
-  Component1,
-  Component2,
-  text,
-  link,
-}: any) {
+export default function PrivatePage({ Component, text, link }: any) {
   const navigate = useNavigate();
   useEffect(() => {
-    if (IsLogin()) {
+    if (!IsLogin()) {
       navigate(link, { replace: true });
       alert(text);
     }
   }, [IsLogin]);
 
-  return IsLogin() ? <Component1 /> : <Component2 />;
+  return IsLogin() ? <Component /> : <MainPage />;
 }

--- a/src/pages/Auth/components/DivisionAuth/PublicPage.tsx
+++ b/src/pages/Auth/components/DivisionAuth/PublicPage.tsx
@@ -1,6 +1,16 @@
-// import IsLogin from "./IsLogin";
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import IsLogin from "./IsLogin";
+import MainPage from "pages/MainPage";
 
-// export default function PublicPages({ Component, restricted }: any) {
-//   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-//   return IsLogin() && restricted ? <AfterLogin /> : <Component />;
-// }
+export default function PublicPage({ Component, text, link }: any) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (IsLogin()) {
+      navigate(link, { replace: true });
+      alert(text);
+    }
+  }, [IsLogin]);
+
+  return IsLogin() ? <MainPage /> : <Component />;
+}

--- a/src/pages/Auth/components/DivisionAuth/PublicPage.tsx
+++ b/src/pages/Auth/components/DivisionAuth/PublicPage.tsx
@@ -1,0 +1,6 @@
+// import IsLogin from "./IsLogin";
+
+// export default function PublicPages({ Component, restricted }: any) {
+//   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+//   return IsLogin() && restricted ? <AfterLogin /> : <Component />;
+// }

--- a/src/pages/Auth/components/LogoutBtn/LogoutBtn.module.scss
+++ b/src/pages/Auth/components/LogoutBtn/LogoutBtn.module.scss
@@ -1,0 +1,11 @@
+.logoutBtn {
+  width: 6rem;
+  height: 3rem;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-right: 4rem;
+  margin-top: 2rem;
+}

--- a/src/pages/Auth/components/LogoutBtn/index.tsx
+++ b/src/pages/Auth/components/LogoutBtn/index.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+import styles from "./LogoutBtn.module.scss";
+
+function LogoutBtn() {
+  const navigate = useNavigate();
+  const clickLogoutBtn = () => {
+    if (confirm("정말로 로그아웃을 하시겠습니까?")) {
+      localStorage.removeItem("accessToken");
+      // localStorage.removeItem("refreshToken");
+      navigate("/");
+    } else {
+      console.log("로그아웃 취소");
+    }
+  };
+  return (
+    <button className={styles.logoutBtn} onClick={clickLogoutBtn}>
+      로그아웃
+    </button>
+  );
+}
+
+export default LogoutBtn;

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const NotFound = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <h1>에러페이지입니당</h1>
+      <button
+        onClick={() => {
+          navigate(-1);
+        }}
+      >
+        뒤로가기
+      </button>
+    </>
+  );
+};
+
+export default NotFound;

--- a/src/pages/IncorrectNote/IncorrectNoteList/IncorrectNoteListPage.module.scss
+++ b/src/pages/IncorrectNote/IncorrectNoteList/IncorrectNoteListPage.module.scss
@@ -4,10 +4,20 @@
   align-items: center;
   justify-content: center;
 
+  &__home {
+    width: 100%;
+    img {
+      width: 2.7rem;
+      margin-left: 2rem;
+      margin-top: 2rem;
+    }
+  }
+
   &__title {
     font-size: 5rem;
     text-align: center;
     margin-bottom: 5rem;
+    margin-top: 0;
   }
   &__incorrectlist {
     width: 80%;

--- a/src/pages/IncorrectNote/IncorrectNoteList/index.tsx
+++ b/src/pages/IncorrectNote/IncorrectNoteList/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import IncorrectNoteBox from "../components/ListCarousel";
 import styles from "./IncorrectNoteListPage.module.scss";
+import { Link } from "react-router-dom";
 
 function IncorrectNotePage() {
   interface incorrectData {
@@ -41,6 +42,10 @@ function IncorrectNotePage() {
 
   return (
     <div className={styles["incorrect-wrap"]}>
+      <Link to="/main" className={styles["incorrect-wrap__home"]}>
+        <img src="images/home.svg" alt="home" />
+      </Link>
+
       <h1 className={styles["incorrect-wrap__title"]}>오답노트</h1>
       <div className={styles["incorrect-wrap__incorrectlist"]}>
         <IncorrectNoteBox label="자음" data={consonant} />

--- a/src/pages/MainPage/MainPage.module.scss
+++ b/src/pages/MainPage/MainPage.module.scss
@@ -27,7 +27,7 @@
   &__common-btn-wrap-no {
     width: 75%;
     display: flex;
-    justify-content: center;
+    justify-content: space-around;
     align-items: center;
   }
   &__common-btn-wrap-yes {

--- a/src/pages/MainPage/MainPage.module.scss
+++ b/src/pages/MainPage/MainPage.module.scss
@@ -19,7 +19,13 @@
     margin-bottom: 8rem;
   }
 
-  &__common-btn-wrap {
+  &__common-btn-wrap-no {
+    width: 75%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  &__common-btn-wrap-yes {
     width: 75%;
     display: flex;
     justify-content: space-between;

--- a/src/pages/MainPage/MainPage.module.scss
+++ b/src/pages/MainPage/MainPage.module.scss
@@ -1,8 +1,13 @@
+.logout {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
 .content {
   position: absolute;
   width: 55rem;
   height: 40rem;
-  top: 50%;
+  top: 45%;
   left: 50%;
   transform: translate(-50%, -50%);
 

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import styles from "./MainPage.module.scss";
 
 function MainPage() {
+  console.log(!(localStorage.getItem("accessToken") == null));
   return (
     <div className={styles.content}>
       <h1>
@@ -11,17 +12,25 @@ function MainPage() {
         <br />
         Sign-language-Quiz
       </h1>
-      <div className={styles["content__common-btn-wrap"]}>
-        <Link to="/game">
-          <CommonButton buttonName="시작하기" />
-        </Link>
-        <Link to="/rank">
-          <CommonButton buttonName="랭킹확인" />
-        </Link>
-        <Link to="/incorrectnote">
-          <CommonButton buttonName="오답노트" />
-        </Link>
-      </div>
+      {localStorage.getItem("accessToken") == null ? (
+        <div className={styles["content__common-btn-wrap-no"]}>
+          <Link to="/signin">
+            <CommonButton buttonName="시작하기" />
+          </Link>
+        </div>
+      ) : (
+        <div className={styles["content__common-btn-wrap-yes"]}>
+          <Link to="/game">
+            <CommonButton buttonName="시작하기" />
+          </Link>
+          <Link to="/rank">
+            <CommonButton buttonName="랭킹확인" />
+          </Link>
+          <Link to="/incorrectnote">
+            <CommonButton buttonName="오답노트" />
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,37 +1,53 @@
 import CommonButton from "components/CommonButton";
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import styles from "./MainPage.module.scss";
+import LogoutBtn from "pages/Auth/components/LogoutBtn";
 
 function MainPage() {
-  console.log(!(localStorage.getItem("accessToken") == null));
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem("accessToken") == null) {
+      navigate("/");
+    }
+  }, [navigate]);
   return (
-    <div className={styles.content}>
-      <h1>
-        수 퀴즈
-        <br />
-        Sign-language-Quiz
-      </h1>
+    <>
       {localStorage.getItem("accessToken") == null ? (
-        <div className={styles["content__common-btn-wrap-no"]}>
-          <Link to="/signin">
-            <CommonButton buttonName="시작하기" />
-          </Link>
-        </div>
+        <></>
       ) : (
-        <div className={styles["content__common-btn-wrap-yes"]}>
-          <Link to="/game">
-            <CommonButton buttonName="시작하기" />
-          </Link>
-          <Link to="/rank">
-            <CommonButton buttonName="랭킹확인" />
-          </Link>
-          <Link to="/incorrectnote">
-            <CommonButton buttonName="오답노트" />
-          </Link>
+        <div className={styles.logout}>
+          <LogoutBtn />
         </div>
       )}
-    </div>
+      <div className={styles.content}>
+        <h1>
+          수 퀴즈
+          <br />
+          Sign-language-Quiz
+        </h1>
+        {localStorage.getItem("accessToken") == null ? (
+          <div className={styles["content__common-btn-wrap-no"]}>
+            <Link to="/signin">
+              <CommonButton buttonName="시작하기" />
+            </Link>
+          </div>
+        ) : (
+          <div className={styles["content__common-btn-wrap-yes"]}>
+            <Link to="/game">
+              <CommonButton buttonName="시작하기" />
+            </Link>
+            <Link to="/rank">
+              <CommonButton buttonName="랭킹확인" />
+            </Link>
+            <Link to="/incorrectnote">
+              <CommonButton buttonName="오답노트" />
+            </Link>
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -7,14 +7,16 @@ import LogoutBtn from "pages/Auth/components/LogoutBtn";
 function MainPage() {
   const navigate = useNavigate();
 
+  const isAuth = localStorage.getItem("accessToken");
+
   useEffect(() => {
-    if (localStorage.getItem("accessToken") == null) {
+    if (isAuth == null) {
       navigate("/");
     }
   }, [navigate]);
   return (
     <>
-      {localStorage.getItem("accessToken") == null ? (
+      {isAuth == null ? (
         <></>
       ) : (
         <div className={styles.logout}>
@@ -27,10 +29,13 @@ function MainPage() {
           <br />
           Sign-language-Quiz
         </h1>
-        {localStorage.getItem("accessToken") == null ? (
+        {isAuth == null ? (
           <div className={styles["content__common-btn-wrap-no"]}>
             <Link to="/signin">
               <CommonButton buttonName="시작하기" />
+            </Link>
+            <Link to="/rank">
+              <CommonButton buttonName="랭킹확인" />
             </Link>
           </div>
         ) : (

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+
+const Root = () => {
+  return (
+    <>
+      <Outlet></Outlet>
+    </>
+  );
+};
+
+export default Root;


### PR DESCRIPTION

## 진행상황

<hr>

- [x] 시작하기 버튼 눌렀을때 로그인이 되어있지않다면 로그인페이지로 이동
- [x] 로그아웃 버튼이 없음

**[로그인 전 메인페이지]**
<img width="1226" alt="스크린샷 2023-04-16 오후 5 44 08" src="https://user-images.githubusercontent.com/79428205/232287378-7dba878b-d39a-4998-bad8-d8951d15070b.png">

**[로그인 후 메인페이지]**
<img width="1307" alt="스크린샷 2023-04-16 오후 5 46 36" src="https://user-images.githubusercontent.com/79428205/232287515-94314653-1b2d-4c94-9074-f31919b910be.png">

- [x] 로그인이 되어있으면 로그인페이지 못가도록 수정
→ alert창이 두번 띄워지는데, 상위 index.tsx파일에서 StrictMode 제거하면 alert창 한번만 띄워짐(개발할때만 사용되고, 배포하면 사용안되는 기능)
<img width="608" alt="스크린샷 2023-04-16 오후 5 47 48" src="https://user-images.githubusercontent.com/79428205/232287576-58fde979-c3fe-4d97-8a9f-70a95fc2d22f.png">


- [x] 비밀번호가 틀렸을때와 아이디가없을때 메시지가 구분 → 응답값에 따라

**[로그인 시 이메일 틀린 경우]** → 둘다 틀린 경우 이메일 틀린 alert창 나옴
<img width="861" alt="스크린샷 2023-04-16 오후 5 45 09" src="https://user-images.githubusercontent.com/79428205/232287435-f429bb00-1b89-4940-8dc7-f7b082a6b05a.png">

**[로그인 시 비밀번호 틀린 경우]**
<img width="994" alt="스크린샷 2023-04-16 오후 5 46 03" src="https://user-images.githubusercontent.com/79428205/232287488-d491cd43-b814-4301-bcf8-972861db0618.png">


- [x] 오답노트에서 메인가는 버튼
<img width="1482" alt="스크린샷 2023-04-16 오후 5 47 24" src="https://user-images.githubusercontent.com/79428205/232287548-bca87d4c-d76d-4804-b4b7-5305af849317.png">

- [x] 잘못된 url접근 시 에러페이지
<img width="331" alt="스크린샷 2023-04-16 오후 5 53 01" src="https://user-images.githubusercontent.com/79428205/232287840-b8377fc8-eddb-4720-ad9f-cb719e29e202.png">

<hr>

[확인해야할 부분]
- [x] 메인 페이지
- [x] 로그인 이메일, 비밀번호 에러 메시지 구부
- [x] 로그아웃기능
- [x] 로그인 되어 있는 경우 로그인, 회원가입 페이지 이동 접근 불가 
- [x] App.tsx에서의 라우터 정리 → RouterProvider로 변경(전체적인 라우터 관리 용이함)