### PR TITLE
Feature/update ai props/53

### DIFF
--- a/src/api/baseAxios.ts
+++ b/src/api/baseAxios.ts
@@ -31,27 +31,27 @@ baseAxios.interceptors.response.use(
      * 에러코드를 업데이트하면 맞춰서 수정작업을 진행해야합니다.
      */
 
-    if (
-      error.response.status === 401 &&
-      error.response.data.code !== "token_not_valid"
-    ) {
-      const refreshToken = localStorage.getItem("refreshToken");
+    if (error.response.status === 401) {
+      if (error.response.data.code !== "token_not_valid") {
+        const refreshToken = localStorage.getItem("refreshToken");
 
-      if (refreshToken != null) {
-        const refreshedAccessToken = await updateAccessToken(refreshToken);
+        if (refreshToken != null) {
+          const refreshedAccessToken = await updateAccessToken(refreshToken);
 
-        if (
-          refreshedAccessToken !== null &&
-          refreshedAccessToken !== undefined
-        ) {
-          originalRequest.headers.access = `Bearer ${
-            refreshedAccessToken as string
-          }`;
+          if (
+            refreshedAccessToken !== null &&
+            refreshedAccessToken !== undefined
+          ) {
+            originalRequest.headers.access = `Bearer ${
+              refreshedAccessToken as string
+            }`;
 
-          localStorage.setItem("accessToken", refreshedAccessToken);
-          return await baseAxios(originalRequest);
+            localStorage.setItem("accessToken", refreshedAccessToken);
+            return await baseAxios(originalRequest);
+          }
         }
       }
+      console.log("??");
       localStorage.clear();
       alert("로그인 정보가 만료되었습니다. 다시 로그인해주세요");
       window.location.href = "/";

--- a/src/api/baseAxios.ts
+++ b/src/api/baseAxios.ts
@@ -52,10 +52,10 @@ baseAxios.interceptors.response.use(
           return await baseAxios(originalRequest);
         }
       }
+      localStorage.clear();
+      alert("로그인 정보가 만료되었습니다. 다시 로그인해주세요");
+      window.location.href = "/";
     }
-    localStorage.clear();
-    alert("로그인 정보가 만료되었습니다. 다시 로그인해주세요");
-    window.location.href = "/";
 
     return await Promise.reject(error);
   }

--- a/src/components/CommonButton/CommonButton.module.scss
+++ b/src/components/CommonButton/CommonButton.module.scss
@@ -1,7 +1,7 @@
 $yellowbutton: #fad795; //공통 버튼 색
 
 .common-btn {
-  width: 11rem;
+  width: 12rem;
   height: 4.4rem;
   border-radius: 1.5rem;
   background: $yellowbutton;

--- a/src/pages/Game/CategorySelection/index.tsx
+++ b/src/pages/Game/CategorySelection/index.tsx
@@ -16,7 +16,7 @@ const CategorySelection = () => {
       dispatch(selectCategory(index + 1));
     }
 
-    if (index === 2) {
+    if (index >= 2) {
       setInfoMessage(
         "단어&문장의 경우 두 손을 활용해 게임을 진행해주세요 (두 손)"
       );
@@ -73,11 +73,18 @@ const CategorySelection = () => {
           isSelected={selectedButtonIndex === 1}
         />
         <CommonButton
-          buttonName={"단어&문장"}
+          buttonName={"단어&문장(일상)"}
           handleClick={() => {
             handleClick(2);
           }}
           isSelected={selectedButtonIndex === 2}
+        />
+        <CommonButton
+          buttonName={"단어&문장(음식)"}
+          handleClick={() => {
+            handleClick(3);
+          }}
+          isSelected={selectedButtonIndex === 3}
         />
       </div>
     </div>

--- a/src/pages/Game/QuizSolve/index.tsx
+++ b/src/pages/Game/QuizSolve/index.tsx
@@ -29,7 +29,7 @@ const QuizSolve = () => {
         <QuizTimer time={categoryId === 3 ? 20 : 10} />
       </div>
       <div className={styles.bottom}>
-        {categoryId === 3 && (
+        {categoryId >= 3 && (
           <h3
             className={`${styles.bottom__text} ${styles["bottom__text--blink"]}`}
           >

--- a/src/pages/Game/QuizSolve/index.tsx
+++ b/src/pages/Game/QuizSolve/index.tsx
@@ -26,7 +26,7 @@ const QuizSolve = () => {
         <h1 className={styles["header__sub-title"]}>
           {"제한시간 내에 위 단어를 표현해주세요"}
         </h1>
-        <QuizTimer time={categoryId === 3 ? 20 : 10} />
+        <QuizTimer time={categoryId >= 3 ? 20 : 10} />
       </div>
       <div className={styles.bottom}>
         {categoryId >= 3 && (

--- a/src/pages/Game/components/HandDetection/OneHand/index.tsx
+++ b/src/pages/Game/components/HandDetection/OneHand/index.tsx
@@ -38,7 +38,7 @@ function OneHand({ open, targetWord, isInit }: propsType) {
       dispatch(correctQuestion());
     }
 
-    if (categoryId === 3) {
+    if (categoryId >= 3) {
       dispatch(usingTwoHandsMode());
     }
     dispatch(moveNextStage());

--- a/src/pages/Game/components/HandDetection/OneHand/index.tsx
+++ b/src/pages/Game/components/HandDetection/OneHand/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "redux/actions/SignQuizActions";
 
 import styles from "../handDetection.module.scss";
+import { SIGN_WORD } from "utils/constants";
 
 interface propsType {
   open: boolean;
@@ -69,11 +70,13 @@ function OneHand({ open, targetWord, isInit }: propsType) {
       if (mediaPipe.length < 19) return;
       console.log(mediaPipe.length);
       console.log("send");
+      console.log(SIGN_WORD.INIT_VALUE);
 
       ws.current.send(
         JSON.stringify({
           message: mediaPipe,
           categoryId: isInit ? 1 : categoryId,
+          word: isInit ? SIGN_WORD.INIT_VALUE : targetWord,
         })
       );
       setSendMsg(true);
@@ -87,8 +90,7 @@ function OneHand({ open, targetWord, isInit }: propsType) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const data = JSON.parse(e.data);
         console.log(data.message);
-        console.log("target :", targetWord);
-        if (data.message === targetWord) {
+        if (data.message === true) {
           console.log("정답입니다!");
           handleSucess();
         }

--- a/src/pages/Game/components/HandDetection/TwoHands/index.tsx
+++ b/src/pages/Game/components/HandDetection/TwoHands/index.tsx
@@ -79,6 +79,7 @@ function TwoHands({ open, targetWord }: propsType) {
           JSON.stringify({
             message: mediaPipe,
             categoryId: 3,
+            word: targetWord,
           })
         );
         setSendMsg(true);
@@ -93,10 +94,8 @@ function TwoHands({ open, targetWord }: propsType) {
       ws.current.onmessage = function (e: { data: string }) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const data = JSON.parse(e.data);
-        console.log("AI인식 결과: ", data.message);
-        console.log("맞춰야 하는 정답: ", targetWord);
-
-        if (stageState === 1 && data.message === targetWord) {
+        console.log(data.message);
+        if (stageState === 1 && data.message === true) {
           console.log("정답입니다!");
           handleSucess();
         }

--- a/src/pages/IncorrectNote/IncorrectNoteList/index.tsx
+++ b/src/pages/IncorrectNote/IncorrectNoteList/index.tsx
@@ -36,6 +36,10 @@ function IncorrectNotePage() {
           labelName: WORD_TYPE[3],
           labelList: data.filter((item: any) => item.wordtype === "3"),
         },
+        {
+          labelName: WORD_TYPE[4],
+          labelList: data.filter((item: any) => item.wordtype === "4"),
+        },
       ]);
     }
   }, [data]);

--- a/src/pages/IncorrectNote/components/ListCarousel/IncorrectNoteBox.module.scss
+++ b/src/pages/IncorrectNote/components/ListCarousel/IncorrectNoteBox.module.scss
@@ -7,7 +7,7 @@
   margin-bottom: 4rem;
 
   &__label {
-    width: 15%;
+    width: 20%;
     height: 4.5rem;
     display: flex;
     align-items: center;
@@ -20,7 +20,7 @@
   }
 
   &__slide {
-    width: 80%;
+    width: 70%;
     margin-left: 3rem;
 
     &__word {

--- a/src/pages/Playground/index.tsx
+++ b/src/pages/Playground/index.tsx
@@ -6,7 +6,7 @@ function PlaygroudPage() {
   return (
     <div>
       <h1>낙서장 페이지</h1>
-      <TwoHands targetWord="asd" open />
+      <TwoHands targetWord="커피" open />
     </div>
   );
 }

--- a/src/redux/reducers/SignQuizReducer.ts
+++ b/src/redux/reducers/SignQuizReducer.ts
@@ -1,10 +1,10 @@
-import { CATEGORY_MULTIPLIER } from "utils/constants";
+import { CATEGORY_MULTIPLIER, SIGN_WORD } from "utils/constants";
 
 const InitialState = {
   score: 0,
   categoryId: -1,
   targetSignWord: {
-    data: "ㅊ",
+    data: SIGN_WORD.INIT_VALUE,
     id: 9,
   },
   stageState: -1,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,7 +7,8 @@ export const CATEGORY_MULTIPLIER: Record<number, number> = {
 export const WORD_TYPE: Record<number, string> = {
   1: "자음",
   2: "모음",
-  3: "단어&문장",
+  3: "단어&문장(일상)",
+  4: "단어&문장(음식)",
 };
 
 export const SIGN_WORD: Record<string, string> = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,3 +9,7 @@ export const WORD_TYPE: Record<number, string> = {
   2: "모음",
   3: "단어&문장",
 };
+
+export const SIGN_WORD: Record<string, string> = {
+  INIT_VALUE: "ㅊ",
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,10 @@
 export const CATEGORY_MULTIPLIER: Record<number, number> = {
   1: 1.1, // 자음은 1.1배
   2: 1.2, // 모음은 1.2배
-  3: 1.4,
+  3: 1.4, // 단어종류는 1.3배
+  4: 1.4,
+  5: 1.4,
+  6: 1.4,
 };
 
 export const WORD_TYPE: Record<number, string> = {


### PR DESCRIPTION
## 진행상황

- AI 정답 처리 로직 수정 (정답 라벨도 api props로 넘기고 응답으로는 true, false가 옴)

- 음식에 대한 카테고리 추가 
 (카테고리 선택버튼 css 및 오답노트 css 수정)

- 오답노트에 새로운 카테고리 정보 표현되도록 업데이트 

### 스크린샷
<img width="1462" alt="image" src="https://github.com/TUK-2023-Project/frontend/assets/78795820/264718d5-36bf-40e1-a977-4461103ff7e5">

<img width="1462" alt="image" src="https://github.com/TUK-2023-Project/frontend/assets/78795820/5b400268-746a-491b-8bf3-c7730009e71e">

[테스트]

이 테스트는 https://github.com/TUK-2023-Project/backend/pull/19 링크의 백엔드 브랜치로 이동 후 같이 테스트되어야합니다.

- [x] 단어(일상) 기능이 기존과 같이 정상적으로 동작하는지 확인

- [x] 메인 페이지의 추가된 카테고리 버튼 확인 (스크린샷 참고)

- [x] 단어(음식) 카테고리를 선택후 게임을 진행했을때 정상동작 확인 (현재는 DB에 3개의 값을 임의로 넣어두었습니다)

- [x] 오답노트 페이지 확인 (스크린샷 참고)
(인식 로그는 Docker상에서 확인가능합니다. 음식에 대한 카테고리를 선택했다면 정답은 음식 데이터에 대한 AI를 실행)
