### PR TITLE
Feature/update category select page/55

### DIFF
--- a/src/components/CommonButton/CommonButton.module.scss
+++ b/src/components/CommonButton/CommonButton.module.scss
@@ -1,23 +1,32 @@
-$yellowbutton: #fad795; //공통 버튼 색
+$yellowButton: #ffdc9b; //공통 버튼 색
+$orangeButton: #fdc65f;
 
 .common-btn {
   width: 12rem;
   height: 4.4rem;
   border-radius: 1.5rem;
-  background: $yellowbutton;
   font-size: 1.5rem;
   font-weight: 900;
   border: 1.8px solid black;
+
+  &.yellow {
+    background: $yellowButton;
+  }
+
+  &.orange {
+    background: $orangeButton;
+  }
+
   &:hover {
-    background: darken($yellowbutton, 10%);
+    background: darken($yellowButton, 20%);
   }
   &:focus {
     outline: none;
     box-shadow: none;
   }
 
-  &--selected {
-    background: darken($yellowbutton, 10%);
-    border: 3px solid #ffc21b;
+  &.common-btn--selected {
+    background: darken($yellowButton, 30%);
+    border: 3px solid #f76504;
   }
 }

--- a/src/components/CommonButton/index.tsx
+++ b/src/components/CommonButton/index.tsx
@@ -5,18 +5,20 @@ interface CommonButtonProps {
   buttonName: string;
   handleClick?: () => void;
   isSelected?: boolean;
+  color?: string;
 }
 
 function CommonButton({
   buttonName,
   handleClick,
   isSelected = false,
+  color = "yellow",
 }: CommonButtonProps) {
   return (
     <button
       className={`${styles["common-btn"]} ${
         isSelected ? styles["common-btn--selected"] : ""
-      }`}
+      } ${styles[color]}`}
       onClick={handleClick}
     >
       {buttonName}

--- a/src/pages/Game/CategorySelection/CategorySelection.module.scss
+++ b/src/pages/Game/CategorySelection/CategorySelection.module.scss
@@ -19,8 +19,9 @@
     font-size: 1.2rem;
   }
 
-  &__sub-title--invisible {
-    display: hidden;
+  &__sub-title--highlight {
+    color: red;
+    font-weight: bold;
   }
 }
 

--- a/src/pages/Game/CategorySelection/CategorySelection.module.scss
+++ b/src/pages/Game/CategorySelection/CategorySelection.module.scss
@@ -5,7 +5,7 @@
   justify-content: flex-end;
   align-items: center;
   position: relative;
-  padding: 30px;
+  padding: 10px;
   margin: auto;
   width: 90%;
 
@@ -25,10 +25,26 @@
 }
 
 .category-wrapper {
-  padding-top: 50px;
+  padding-top: 20px;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
   width: 80%;
   margin: 0 auto;
+  &__row {
+    margin-bottom: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+
+    &:first-child {
+      justify-content: space-around;
+    }
+
+    &:last-child {
+      justify-content: space-between;
+    }
+  }
 }

--- a/src/pages/Game/CategorySelection/index.tsx
+++ b/src/pages/Game/CategorySelection/index.tsx
@@ -81,6 +81,7 @@ const CategorySelection = () => {
               handleClick(2);
             }}
             isSelected={selectedButtonIndex === 2}
+            color="orange"
           />
           <CommonButton
             buttonName={WORD_TYPE[4]}
@@ -88,6 +89,7 @@ const CategorySelection = () => {
               handleClick(3);
             }}
             isSelected={selectedButtonIndex === 3}
+            color="orange"
           />
           <CommonButton
             buttonName={WORD_TYPE[5]}
@@ -95,6 +97,7 @@ const CategorySelection = () => {
               handleClick(4);
             }}
             isSelected={selectedButtonIndex === 4}
+            color="orange"
           />
         </div>
       </div>

--- a/src/pages/Game/CategorySelection/index.tsx
+++ b/src/pages/Game/CategorySelection/index.tsx
@@ -33,25 +33,11 @@ const CategorySelection = () => {
         <h1 className={styles.header__title}>
           {"풀이하고자 하는 퀴즈의 카테고리를 선택해주세요"}
         </h1>
-        <h1
-          className={
-            selectedButtonIndex !== null
-              ? styles["header__sub-title"]
-              : styles["header__sub-title"]
-          }
-        >
+        <h1 className={styles["header__sub-title"]}>
           {"선택이 완료되었다면 오른손을 활짝 펼쳐 카메라에 비춰주세요"}
         </h1>
         <h1
-          className={
-            selectedButtonIndex !== null
-              ? styles["header__sub-title"]
-              : styles["header__sub-title"]
-          }
-          style={{
-            color: "red",
-            fontWeight: "bold",
-          }}
+          className={`${styles["header__sub-title"]} ${styles["header__sub-title--highlight"]}`}
         >
           {infoMessage}
         </h1>

--- a/src/pages/Game/CategorySelection/index.tsx
+++ b/src/pages/Game/CategorySelection/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 import { selectCategory } from "redux/actions/SignQuizActions";
 import CommonButton from "components/CommonButton";
 import styles from "./CategorySelection.module.scss";
-
+import { WORD_TYPE } from "utils/constants";
 const CategorySelection = () => {
   const dispatch = useDispatch();
 
@@ -59,32 +59,39 @@ const CategorySelection = () => {
 
       <div className={styles["category-wrapper"]}>
         <CommonButton
-          buttonName={"자음"}
+          buttonName={WORD_TYPE[1]}
           handleClick={() => {
             handleClick(0);
           }}
           isSelected={selectedButtonIndex === 0}
         />
         <CommonButton
-          buttonName={"모음"}
+          buttonName={WORD_TYPE[2]}
           handleClick={() => {
             handleClick(1);
           }}
           isSelected={selectedButtonIndex === 1}
         />
         <CommonButton
-          buttonName={"단어&문장(일상)"}
+          buttonName={WORD_TYPE[3]}
           handleClick={() => {
             handleClick(2);
           }}
           isSelected={selectedButtonIndex === 2}
         />
         <CommonButton
-          buttonName={"단어&문장(음식)"}
+          buttonName={WORD_TYPE[4]}
           handleClick={() => {
             handleClick(3);
           }}
           isSelected={selectedButtonIndex === 3}
+        />
+        <CommonButton
+          buttonName={WORD_TYPE[5]}
+          handleClick={() => {
+            handleClick(4);
+          }}
+          isSelected={selectedButtonIndex === 4}
         />
       </div>
     </div>

--- a/src/pages/Game/CategorySelection/index.tsx
+++ b/src/pages/Game/CategorySelection/index.tsx
@@ -58,41 +58,45 @@ const CategorySelection = () => {
       </div>
 
       <div className={styles["category-wrapper"]}>
-        <CommonButton
-          buttonName={WORD_TYPE[1]}
-          handleClick={() => {
-            handleClick(0);
-          }}
-          isSelected={selectedButtonIndex === 0}
-        />
-        <CommonButton
-          buttonName={WORD_TYPE[2]}
-          handleClick={() => {
-            handleClick(1);
-          }}
-          isSelected={selectedButtonIndex === 1}
-        />
-        <CommonButton
-          buttonName={WORD_TYPE[3]}
-          handleClick={() => {
-            handleClick(2);
-          }}
-          isSelected={selectedButtonIndex === 2}
-        />
-        <CommonButton
-          buttonName={WORD_TYPE[4]}
-          handleClick={() => {
-            handleClick(3);
-          }}
-          isSelected={selectedButtonIndex === 3}
-        />
-        <CommonButton
-          buttonName={WORD_TYPE[5]}
-          handleClick={() => {
-            handleClick(4);
-          }}
-          isSelected={selectedButtonIndex === 4}
-        />
+        <div className={styles["category-wrapper__row"]}>
+          <CommonButton
+            buttonName={WORD_TYPE[1]}
+            handleClick={() => {
+              handleClick(0);
+            }}
+            isSelected={selectedButtonIndex === 0}
+          />
+          <CommonButton
+            buttonName={WORD_TYPE[2]}
+            handleClick={() => {
+              handleClick(1);
+            }}
+            isSelected={selectedButtonIndex === 1}
+          />
+        </div>
+        <div className={styles["category-wrapper__row"]}>
+          <CommonButton
+            buttonName={WORD_TYPE[3]}
+            handleClick={() => {
+              handleClick(2);
+            }}
+            isSelected={selectedButtonIndex === 2}
+          />
+          <CommonButton
+            buttonName={WORD_TYPE[4]}
+            handleClick={() => {
+              handleClick(3);
+            }}
+            isSelected={selectedButtonIndex === 3}
+          />
+          <CommonButton
+            buttonName={WORD_TYPE[5]}
+            handleClick={() => {
+              handleClick(4);
+            }}
+            isSelected={selectedButtonIndex === 4}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,6 +12,7 @@ export const WORD_TYPE: Record<number, string> = {
   2: "모음",
   3: "단어&문장(일상)",
   4: "단어&문장(음식)",
+  5: "단어&문장(동물)",
 };
 
 export const SIGN_WORD: Record<string, string> = {


### PR DESCRIPTION
## 진행상황

- 카테고리 추가(동물)

- 카테고리 선택 페이지 UI수정 (2행으로 자음&모음 // 단어텝 분리)

- commonButton 컴포넌트에 color props추가 및 난이도에 따른 카테고리 선택 버튼 색상 수정

- 선택된 카테고리에 대한 테두리 강조 CSS 추가


### 스크린샷
<img width="1443" alt="image" src="https://github.com/TUK-2023-Project/frontend/assets/78795820/d0a4f2ba-2ee3-405c-ac14-8d10d67d8cc3">

<img width="1446" alt="image" src="https://github.com/TUK-2023-Project/frontend/assets/78795820/7ed9c6de-62ac-4104-8c1e-bdf3f1d1d52b">


[테스트]

http://localhost:3000/game 페이지로 이동해 카테고리 선택화면을 확인해주세요( 스크린샷 참고 )

- [x] 카테고리 페이지가 2행으로 표현되는지 확인

[ 논의사항 & 이슈 ]

임의로 난이도에 따른 색상을 조금 다르게두고 클릭된 버튼은 빨간색 테두리 효과를 넣었는데 어색한부분이 있다면 말씀부탁드립니다!!